### PR TITLE
Update ManagementService.py

### DIFF
--- a/Pedestrian/ManagementService.py
+++ b/Pedestrian/ManagementService.py
@@ -125,7 +125,7 @@ def management(start_point, walking_time_period, walking_speed, distance_decay_f
         poi_data = '"NULL"'
         crime_data = '"NULL"'
         #return aggregation_data
-    result = '{"walkshed": %s, "poi": %s}' % (aggregation_data)
+    result = '{"walkshed": %s, "poi": %s}' % (aggregation_data, poi_data)
     return result
 
 


### PR DESCRIPTION
Hey Ebrahim,

as I wrote yesterday: chaining the single services works, but using the (pedestrian) Management service directly does not. Here the error that gets thrown:

  File "/home/ssteinig/wypmodels/Network-PedestrianOnly/bottle.py", line 1575, in wrapper
    rv = callback(_a, *_ka)
  File "ManagementService.py", line 140, in service
    return management(start_point, walking_time_period, walking_speed, distance_decay_function)
  File "ManagementService.py", line 128, in management
    result = '{"walkshed": %s, "poi": %s}' % (aggregation_data)
TypeError: not enough arguments for format string

which seems to make sense, because in the Bike Management service it looks like this:
result = '{"walkshed": %s, "poi": %s}' % (aggregation_data, poi_data)

So when I added poin_data it runs.

stefan
